### PR TITLE
fixes from compiling with warnings

### DIFF
--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -930,7 +930,7 @@ typedef struct PyArrayFlagsObject {
         int flags;
 } PyArrayFlagsObject;
 
-HPyType_HELPERS(PyArrayFlagsObject);
+HPyType_LEGACY_HELPERS(PyArrayFlagsObject);
 
 /* Mirrors buffer object to ptr */
 

--- a/numpy/core/src/common/npy_hashtable.c
+++ b/numpy/core/src/common/npy_hashtable.c
@@ -257,7 +257,7 @@ PyArrayIdentityHash_SetItem(PyArrayIdentityHash *tb, PyObject *cache_owner,
 
 
 NPY_NO_EXPORT PyObject *
-PyArrayIdentityHash_GetItem(PyObject *cache_owner, PyArrayIdentityHash const *tb, PyObject *const *key)
+PyArrayIdentityHash_GetItem(PyArrayIdentityHash const *tb, PyObject *cache_owner, PyObject *const *key)
 {
     HPyContext *ctx = npy_get_context();
     HPy h_cache_owner = HPy_FromPyObject(ctx, cache_owner);

--- a/numpy/core/src/common/npy_hashtable.h
+++ b/numpy/core/src/common/npy_hashtable.h
@@ -21,8 +21,8 @@ PyArrayIdentityHash_SetItem(PyArrayIdentityHash *tb, PyObject *cache_owner,
         PyObject *const *key, PyObject *value, int replace);
 
 NPY_NO_EXPORT PyObject *
-PyArrayIdentityHash_GetItem(PyObject *cache_owner,
-        PyArrayIdentityHash const *tb, PyObject *const *key);
+PyArrayIdentityHash_GetItem(PyArrayIdentityHash const *tb, PyObject *cache_owner,
+        PyObject *const *key);
 
 NPY_NO_EXPORT PyArrayIdentityHash *
 PyArrayIdentityHash_New(int key_len);

--- a/numpy/core/src/multiarray/abstractdtypes.c
+++ b/numpy/core/src/multiarray/abstractdtypes.c
@@ -108,18 +108,21 @@ NPY_NO_EXPORT HPyType_Spec HPyArray_PyIntAbstractDType_spec = {
     .name = "numpy._IntegerAbstractDType",
     .basicsize = sizeof(PyArray_Descr),
     .flags = Py_TPFLAGS_DEFAULT,
+    .builtin_shape = HPyType_BuiltinShape_Legacy
 };
 
 NPY_NO_EXPORT HPyType_Spec HPyArray_PyFloatAbstractDType_spec = {
     .name = "numpy._FloatAbstractDType",
     .basicsize = sizeof(PyArray_Descr),
     .flags = HPy_TPFLAGS_DEFAULT,
+    .builtin_shape = HPyType_BuiltinShape_Legacy
 };
 
 NPY_NO_EXPORT HPyType_Spec HPyArray_PyComplexAbstractDType_spec = {
     .name = "numpy._ComplexAbstractDType",
     .basicsize = sizeof(PyArray_Descr),
     .flags = HPy_TPFLAGS_DEFAULT,
+    .builtin_shape = HPyType_BuiltinShape_Legacy
 };
 
 // "forward" declarations:

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -1154,4 +1154,5 @@ NPY_NO_EXPORT HPyType_Spec PyBoundArrayMethod_Type_Spec = {
     .basicsize = sizeof(PyBoundArrayMethodObject),
     .flags = HPy_TPFLAGS_DEFAULT,
     .defines = boundarraymethod_defines,
+    .builtin_shape = SHAPE(PyBoundArrayMethodObject),
 };

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -224,12 +224,13 @@ HPyType_LEGACY_HELPERS(PyArrayMethodObject)
  * on the `ArrayMethod` itself.
  */
 typedef struct {
+    PyObject_HEAD
     HPyField *dtypes; /* PyArray_DTypeMeta **dtypes */
     HPyField method; /* PyArrayMethodObject *method */
     int nargs; /* method->nin + method->nout */
 } PyBoundArrayMethodObject;
 
-HPyType_HELPERS(PyBoundArrayMethodObject)
+HPyType_LEGACY_HELPERS(PyBoundArrayMethodObject)
 
 
 extern NPY_NO_EXPORT PyTypeObject *PyArrayMethod_Type;

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -630,7 +630,7 @@ static NPY_INLINE npy_longdouble
 hpy_string_to_long_double(HPyContext *ctx, HPy op)
 {
     const char *s;
-    const char *end;
+    char *end;
     npy_longdouble temp;
     HPy b;
 

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -2331,7 +2331,7 @@ HPyArray_FromAny(HPyContext *ctx, HPy op, HPy newtype, int min_depth,
             }
 
             // TODO HPY LABS PORT
-            PyArrayObject *py_ret = HPy_AsPyObject(ctx, ret);
+            PyArrayObject *py_ret = (PyArrayObject *)HPy_AsPyObject(ctx, ret);
             PyObject *py_op = HPy_AsPyObject(ctx, op);
             if (setArrayFromSequence(py_ret, py_op, 0, NULL) < 0) {
                 Py_DECREF(py_ret);
@@ -4986,7 +4986,7 @@ HPyArray_ArangeObj(HPyContext *ctx, HPy start, HPy stop, HPy step, HPy /* PyArra
         PyObject *new;
         PyObject *py_range = HPy_AsPyObject(ctx, range);
         CAPI_WARN("calling PyArray_Byteswap");
-        new = PyArray_Byteswap(py_range, 1);
+        new = PyArray_Byteswap((PyArrayObject *)py_range, 1);
         Py_DECREF(py_range);
         Py_DECREF(new);
         _hpy_set_descr(ctx, range, range_struct, dtype);

--- a/numpy/core/src/multiarray/datetime_strings.c
+++ b/numpy/core/src/multiarray/datetime_strings.c
@@ -1533,7 +1533,7 @@ datetime_as_string_impl(HPyContext *ctx, HPy NPY_UNUSED(ignored), const HPy *arg
     op_flags[1] = NPY_ITER_WRITEONLY|
                   NPY_ITER_ALLOCATE;
 
-    iter = NpyIter_MultiNew(2, op, flags, NPY_KEEPORDER, NPY_UNSAFE_CASTING,
+    iter = HNpyIter_MultiNew(ctx, 2, op, flags, NPY_KEEPORDER, NPY_UNSAFE_CASTING,
                             op_flags, op_dtypes);
     if (iter == NULL) {
         goto fail;

--- a/numpy/core/src/multiarray/descriptor.c
+++ b/numpy/core/src/multiarray/descriptor.c
@@ -425,7 +425,7 @@ _hpy_convert_from_tuple(HPyContext *ctx, HPy obj, int align)
         }
         newdescr_struct->flags = type_struct->flags;
         newdescr_struct->alignment = type_struct->alignment;
-        newdescr_struct->subarray->base = HPy_AsPyObject(ctx, type);
+        newdescr_struct->subarray->base = (PyArray_Descr*)HPy_AsPyObject(ctx, type);
         HPy_Close(ctx, type);
         Py_XDECREF(newdescr_struct->fields);
         HPyField_Store(ctx, newdescr, &newdescr_struct->names, HPy_NULL);
@@ -2230,7 +2230,7 @@ arraydescr_base_get(HPyContext *ctx, HPy /* PyArray_Descr * */ self, void *NPY_U
         return HPy_Dup(ctx, self);
     }
     // Py_INCREF(self->subarray->base);
-    return HPy_FromPyObject(ctx, self_struct->subarray->base);
+    return HPy_FromPyObject(ctx, (PyObject*)self_struct->subarray->base);
 }
 
 HPyDef_GET(arraydescr_shape, "shape")
@@ -2585,7 +2585,7 @@ arraydescr_new_impl(HPyContext *ctx, HPy subtype, const HPy *args,
     if (!HPyGlobal_Is(ctx, subtype, HPyArrayDescr_Type)) {
         HPy subtype_type = HPy_Type(ctx, subtype);
         PyArray_DTypeMeta *DType = PyArray_DTypeMeta_AsStruct(ctx, subtype);
-        PyTypeObject *subtype_typeobj = HPy_AsPyObject(ctx, subtype);
+        PyTypeObject *subtype_typeobj = (PyTypeObject*)HPy_AsPyObject(ctx, subtype);
         if (HPyGlobal_Is(ctx, subtype_type, HPyArrayDTypeMeta_Type) &&
                 (HNPY_DT_SLOTS(ctx, subtype)) != NULL &&
                 !NPY_DT_is_legacy(DType) &&
@@ -3626,10 +3626,10 @@ HPyArray_DescrNewByteorder(HPyContext *ctx, HPy /* PyArray_Descr * */ self, char
         Py_DECREF(new_data->subarray->base);
         PyArray_Descr *self_data = PyArray_Descr_AsStruct(ctx, self);
         CAPI_WARN("using subarray->base");
-        HPy base = HPy_FromPyObject(ctx, self_data->subarray->base);
+        HPy base = HPy_FromPyObject(ctx, (PyObject*)(self_data->subarray->base));
         HPy byteorder = HPyArray_DescrNewByteorder(ctx, base, newendian);
         HPy_Close(ctx, base);
-        new_data->subarray->base = HPy_AsPyObject(ctx, byteorder);
+        new_data->subarray->base = (PyArray_Descr*)HPy_AsPyObject(ctx, byteorder);
         if (new_data->subarray->base == NULL) {
             HPy_Close(ctx, new);
             return HPy_NULL;

--- a/numpy/core/src/multiarray/dlpack.c
+++ b/numpy/core/src/multiarray/dlpack.c
@@ -106,7 +106,7 @@ hpy_array_get_dl_device(HPyContext *ctx, HPy /* PyArrayObject * */ self) {
 static DLDevice
 array_get_dl_device(PyArrayObject *self) {
     HPyContext *ctx = npy_get_context();
-    HPy h_self = HPy_FromPyObject(ctx, self);
+    HPy h_self = HPy_FromPyObject(ctx, (PyObject *)self);
     DLDevice ret = hpy_array_get_dl_device(ctx, h_self);
     HPy_Close(ctx, h_self);
     return ret;
@@ -419,7 +419,7 @@ _from_dlpack_impl(HPyContext *ctx, HPy NPY_UNUSED(self), HPy obj) {
 
     HPy new_capsule = HPyCapsule_New(ctx, managed,
             NPY_DLPACK_INTERNAL_CAPSULE_NAME,
-            array_dlpack_internal_capsule_deleter);
+            (HPyCapsule_Destructor*)array_dlpack_internal_capsule_deleter);
     if (HPy_IsNull(new_capsule)) {
         HPy_Close(ctx, capsule);
         HPy_Close(ctx, ret);

--- a/numpy/core/src/multiarray/dtype_transfer.c
+++ b/numpy/core/src/multiarray/dtype_transfer.c
@@ -2920,7 +2920,7 @@ hpy_get_decref_transfer_function(HPyContext *ctx, int aligned,
         }
         src_size = PyArray_MultiplyList(src_shape.ptr, src_shape.len);
         npy_free_cache_dim_obj(src_shape);
-        HPy h_base = HPy_FromPyObject(ctx, src_dtype_data->subarray->base);
+        HPy h_base = HPy_FromPyObject(ctx, (PyObject *)(src_dtype_data->subarray->base));
         PyArray_Descr *base_data = src_dtype_data->subarray->base;
         if (get_n_to_n_transfer_function(ctx, aligned,
                 src_stride, 0,
@@ -3669,13 +3669,13 @@ wrap_aligned_transferfunction(
     HPyContext *ctx = npy_get_context();
     /* These are always legacy casts that only support native-byte-order: */
     // Py_INCREF(src_wrapped_dtype); // HPy_FromPyObject will incref
-    castdata.main.descriptors[0] = HPy_FromPyObject(ctx, src_wrapped_dtype);
+    castdata.main.descriptors[0] = HPy_FromPyObject(ctx, (PyObject *)src_wrapped_dtype);
     if (HPy_IsNull(castdata.main.descriptors[0])) {
         castdata.main.descriptors[1] = HPy_NULL;
         goto fail;
     }
     // Py_INCREF(dst_wrapped_dtype); // HPy_FromPyObject will incref
-    castdata.main.descriptors[1] = HPy_FromPyObject(ctx, dst_wrapped_dtype);
+    castdata.main.descriptors[1] = HPy_FromPyObject(ctx, (PyObject *)dst_wrapped_dtype);
     if (HPy_IsNull(castdata.main.descriptors[1])) {
         goto fail;
     }

--- a/numpy/core/src/multiarray/dtypemeta.c
+++ b/numpy/core/src/multiarray/dtypemeta.c
@@ -107,6 +107,15 @@ legacy_dtype_default_new_impl(HPyContext *ctx, HPy h_self,
     return HPyField_Load(ctx, h_self, self->singleton);
 }
 
+HPyDef_SLOT(legacy_dtype_tp_traverse, HPy_tp_traverse)
+static int legacy_dtype_tp_traverse_impl(void *self_p, HPyFunc_visitproc visit, void *arg) {
+    PyArray_Descr *self = (PyArray_Descr*) self_p;
+    if (&self->typeobj)
+        HPy_VISIT(&self->typeobj);
+    if (&self->names)
+        HPy_VISIT(&self->names);
+    return 0;
+}
 
 //static PyArray_Descr *
 //nonparametric_discover_descr_from_pyobject(
@@ -599,6 +608,7 @@ hpy_object_common_dtype(HPyContext *ctx, HPy /* PyArray_DTypeMeta * */ cls,
 
 static HPyDef *new_dtype_legacy_defines[] = {
     &legacy_dtype_default_new,
+    &legacy_dtype_tp_traverse,
     NULL
 };
 static HPyType_Spec New_PyArrayDescr_spec_prototype = {

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -741,7 +741,7 @@ static int
 arrayflags_setitem_impl(HPyContext *ctx, HPy self, HPy ind, HPy item)
 {
     const char *key;
-    const char buf[16];
+    char buf[16];
     int n;
     if (HPyUnicode_Check(ctx, ind)) {
         HPy tmp_str;

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -937,6 +937,7 @@ NPY_NO_EXPORT HPyType_Spec PyArrayFlags_Type_Spec = {
     .basicsize = sizeof(PyArrayFlagsObject),
     .flags = HPy_TPFLAGS_DEFAULT,
     .defines = arrayflags_defines,
+    .builtin_shape = HPyType_BuiltinShape_Legacy,
 };
 
 NPY_NO_EXPORT PyTypeObject *_PyArrayFlags_Type_p;

--- a/numpy/core/src/multiarray/flagsobject.c
+++ b/numpy/core/src/multiarray/flagsobject.c
@@ -900,6 +900,15 @@ arrayflags_new_impl(HPyContext *ctx, HPy self, const HPy *args, HPy_ssize_t narg
     return HPyArray_NewFlagsObject(ctx, self, arg);
 }
 
+HPyDef_SLOT(arrayflags_traverse, HPy_tp_traverse)
+static int
+arrayflags_traverse_impl(void *self, HPyFunc_visitproc visit, void *arg)
+{
+    PyArrayFlagsObject *flags = (PyArrayFlagsObject *)self;
+    HPy_VISIT(&flags->arr);
+    return 0;
+}
+
 /*
 static PyType_Slot arrayflags_slots[] = {
         //{Py_tp_str, arrayflags_print},
@@ -929,6 +938,7 @@ static HPyDef *arrayflags_defines[] = {
         &arrayflags_carray,
         &arrayflags_farray,
         &arrayflags_num,
+        &arrayflags_traverse,
         NULL
 };
 

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1133,7 +1133,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     size = it->size;
 
     HPyContext *ctx = npy_get_context();
-    HPy h_op = HPy_FromPyObject(ctx, op);
+    HPy h_op = HPy_FromPyObject(ctx, (PyObject *)op);
 
     if (needcopy) {
         buffer = PyDataMem_UserNEW(N * elsize, mem_handler);
@@ -1205,7 +1205,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
         if (needcopy) {
             if (hasrefs) {
                 if (swap) {
-                    HPy h_op = HPy_FromPyObject(ctx, op);
+                    HPy h_op = HPy_FromPyObject(ctx, (PyObject *)op);
                     copyswapn(ctx, buffer, elsize, NULL, 0, N, swap, h_op);
                 }
                 _unaligned_strided_byte_copy(it->dataptr, astride,

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -2641,6 +2641,7 @@ NPY_NO_EXPORT int
 array_assign_item_slot_impl(HPyContext *ctx, HPy /* PyArrayObject * */ self, HPy_ssize_t i, HPy op)
 {
     npy_index_info indices[2];
+    hpy_npy_index_info hpy_indices[2];
 
     if (HPy_IsNull(op)) {
         HPyErr_SetString(ctx, ctx->h_ValueError,
@@ -2664,6 +2665,8 @@ array_assign_item_slot_impl(HPyContext *ctx, HPy /* PyArrayObject * */ self, HPy
 
     indices[0].value = i;
     indices[0].type = HAS_INTEGER;
+    hpy_indices[0].value = i;
+    hpy_indices[0].type = HAS_INTEGER;
     if (PyArray_NDIM(self_struct) == 1) {
         char *item;
         if (get_item_pointer(self_struct, &item, indices, 1) < 0) {
@@ -2677,9 +2680,9 @@ array_assign_item_slot_impl(HPyContext *ctx, HPy /* PyArrayObject * */ self, HPy
     else {
         HPy view; // PyArrayObject *
         
-        indices[1].value = PyArray_NDIM(self_struct) - 1;
-        indices[1].type = HAS_ELLIPSIS;
-        if (hpy_get_view_from_index(ctx, self, self_struct, &view, indices, 2, 0) < 0) {
+        hpy_indices[1].value = PyArray_NDIM(self_struct) - 1;
+        hpy_indices[1].type = HAS_ELLIPSIS;
+        if (hpy_get_view_from_index(ctx, self, self_struct, &view, hpy_indices, 2, 0) < 0) {
             return -1;
         }
         PyArrayObject *view_struct = PyArrayObject_AsStruct(ctx, view);

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1414,11 +1414,12 @@ hpy_prepare_index(HPyContext *ctx, HPy h_self, PyArrayObject *self, HPy h_index,
         }
     }
     else if (used_ndim > PyArray_NDIM(self)) {
-        HPyErr_SetString(ctx, ctx->h_IndexError,
+        // HPyErr_SetString does not take extra arguments
+        HPyErr_Format(ctx, ctx->h_IndexError,
                      "too many indices for array: "
-                     "array is %d-dimensional, but %d were indexed"
-                     /*,PyArray_NDIM(self),
-                     used_ndim*/);
+                     "array is %d-dimensional, but %d were indexed",
+                     PyArray_NDIM(self),
+                     used_ndim);
         goto failed_building_indices;
     }
     else if (index_ndim == 0) {

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -1414,7 +1414,6 @@ hpy_prepare_index(HPyContext *ctx, HPy h_self, PyArrayObject *self, HPy h_index,
         }
     }
     else if (used_ndim > PyArray_NDIM(self)) {
-        // HPyErr_SetString does not take extra arguments
         HPyErr_Format(ctx, ctx->h_IndexError,
                      "too many indices for array: "
                      "array is %d-dimensional, but %d were indexed",

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4226,13 +4226,13 @@ array_einsum_impl(HPyContext *ctx, HPy NPY_UNUSED(dummy), const HPy *args, size_
         }
     }
     CAPI_WARN("calling PyArray_EinsteinSum");
-    PyArrayObject **py_op_in = HPy_AsPyObjectArray(ctx, op, nop);
-    PyArray_Descr *py_dtype = HPy_AsPyObject(ctx, dtype);
-    PyArrayObject *py_out = HPy_AsPyObject(ctx, out);
+    PyArrayObject **py_op_in = (PyArrayObject **)HPy_AsPyObjectArray(ctx, op, nop);
+    PyArray_Descr *py_dtype = (PyArray_Descr *)HPy_AsPyObject(ctx, dtype);
+    PyArrayObject *py_out = (PyArrayObject *)HPy_AsPyObject(ctx, out);
     PyObject *py_ret = (PyObject *)PyArray_EinsteinSum(subscripts, nop, py_op_in, py_dtype,
                                         order, casting, py_out);
     ret = HPy_FromPyObject(ctx, py_ret);
-    HPy_DecrefAndFreeArray(ctx, py_op_in, nop);
+    HPy_DecrefAndFreeArray(ctx, (PyObject**)py_op_in, nop);
     Py_XDECREF(py_dtype);
     Py_XDECREF(py_out);
     Py_XDECREF(py_ret);

--- a/numpy/core/src/multiarray/nditer_pywrap.c
+++ b/numpy/core/src/multiarray/nditer_pywrap.c
@@ -1644,7 +1644,7 @@ static PyObject *
 npyiter_next(NewNpyArrayIterObject *self)
 {
     HPyContext *ctx = npy_get_context();
-    HPy h_self = HPy_FromPyObject(ctx, self);
+    HPy h_self = HPy_FromPyObject(ctx, (PyObject *)self);
     HPy h_ret = hpy_npyiter_next(ctx, h_self);
     PyObject *ret = HPy_AsPyObject(ctx, h_ret);
     HPy_Close(ctx, h_ret);

--- a/numpy/core/src/multiarray/number.c
+++ b/numpy/core/src/multiarray/number.c
@@ -505,11 +505,11 @@ is_scalar_with_conversion(HPyContext *ctx, HPy h_o2, double* out_exponent)
     // NOTE: do partial porting approach, this looked small, but it isn't!
     else if (PyArray_IsScalar(o2, Integer) ||
                 (optimize_fpexps && PyArray_IsScalar(o2, Floating))) {
-        temp = Py_TYPE(o2)->tp_as_number->nb_float(o2);
+        temp = Py_TYPE(o2)->tp_as_number->nb_float((PyObject *)o2);
         if (temp == NULL) {
             return NPY_NOSCALAR;
         }
-        *out_exponent = PyFloat_AsDouble(o2);
+        *out_exponent = PyFloat_AsDouble((PyObject *)o2);
         Py_DECREF(temp);
 
         if (PyArray_IsScalar(o2, Integer)) {
@@ -520,7 +520,7 @@ is_scalar_with_conversion(HPyContext *ctx, HPy h_o2, double* out_exponent)
         }
     }
     else if (PyIndex_Check((PyObject*) o2)) {
-        PyObject* value = PyNumber_Index(o2);
+        PyObject* value = PyNumber_Index((PyObject *)o2);
         Py_ssize_t val;
         if (value == NULL) {
             if (PyErr_Occurred()) {

--- a/numpy/core/src/multiarray/refcount.c
+++ b/numpy/core/src/multiarray/refcount.c
@@ -144,7 +144,7 @@ HPyArray_Item_INCREF(HPyContext *ctx, char *data, HPy h_descr)
         /* Subarrays are always contiguous in memory */
         size = descr->elsize / inner_elsize;
 
-        HPy h_base = HPy_FromPyObject(ctx, descr->subarray->base);
+        HPy h_base = HPy_FromPyObject(ctx, (PyObject *)(descr->subarray->base));
         for (i = 0; i < size; i++){
             /* Recursively increment the reference count of subarray elements */
             HPyArray_Item_INCREF(ctx, data + i * inner_elsize, h_base);
@@ -281,7 +281,7 @@ HPyArray_Item_XDECREF(HPyContext *ctx, char *data, HPy h_descr)
         /* Subarrays are always contiguous in memory */
         size = descr->elsize / inner_elsize;
 
-        HPy h_base = HPy_FromPyObject(ctx, descr->subarray->base);
+        HPy h_base = HPy_FromPyObject(ctx, (PyObject *)(descr->subarray->base));
         for (i = 0; i < size; i++){
             /* Recursively decrement the reference count of subarray elements */
             HPyArray_Item_XDECREF(ctx, data + i * inner_elsize, h_base);
@@ -510,7 +510,7 @@ _fillobject(char *optr, PyObject *obj, PyArray_Descr *dtype)
                                    0, NULL, NULL, NULL,
                                    0, NULL);
         if (arr!=NULL) {
-            setitem_trampoline(dtype->f->setitem, obj, optr, arr);
+            setitem_trampoline(dtype->f->setitem, obj, optr, (PyArrayObject*)arr);
         }
         Py_XDECREF(arr);
     }
@@ -630,7 +630,7 @@ _hpy_fillobject(HPyContext *ctx, char *optr, HPy obj, HPy /* PyArray_Descr * */ 
 
         /* Call _hpy_fillobject on each item recursively. */
         for (i = 0; i < size; i++){
-            HPy h_base = HPy_FromPyObject(ctx, dtype_struct->subarray->base);
+            HPy h_base = HPy_FromPyObject(ctx, (PyObject*)(dtype_struct->subarray->base));
             _hpy_fillobject(ctx, optr, obj, h_base);
             optr += inner_elsize;
             HPy_Close(ctx, h_base);

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -559,6 +559,12 @@ HPyArray_FromScalar(HPyContext *ctx, HPy h_scalar, /*PyArray_Descr*/ HPy h_outco
     }
     else {
         char *memptr = hpy_scalar_value(ctx, h_scalar, typecode);
+        if (memptr == NULL)
+        {
+            HPy_Close(ctx, h_r);
+            HPy_Close(ctx, h_typecode);
+            return HPy_NULL;
+        }
 
         memcpy(PyArray_DATA(r), memptr, typecode->elsize);
         if (PyDataType_FLAGCHK(typecode, NPY_ITEM_HASOBJECT)) {

--- a/numpy/core/src/multiarray/scalarapi.c
+++ b/numpy/core/src/multiarray/scalarapi.c
@@ -757,7 +757,8 @@ PyArray_DescrFromTypeObject(PyObject *type)
             }
             new->fields = conv->fields;
             Py_XINCREF(new->fields);
-            HPyField_StorePyObj(new, &new->names, HPyField_LoadPyObj(conv, conv->names));
+            HPyField_StorePyObj((PyObject *)new, &new->names,
+                                HPyField_LoadPyObj((PyObject *)conv, conv->names));
             // Py_XINCREF(new->names);
             new->elsize = conv->elsize;
             new->subarray = conv->subarray;
@@ -765,7 +766,7 @@ PyArray_DescrFromTypeObject(PyObject *type)
         }
         Py_DECREF(conv);
         // Py_XDECREF(new->typeobj);
-        HPyField_StorePyObj(new, &new->typeobj, type);
+        HPyField_StorePyObj((PyObject *)new, &new->typeobj, type);
         // Py_INCREF(type);
         return new;
     }
@@ -1063,7 +1064,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
         PyArrayScalar_RETURN_BOOL_FROM_LONG(*(npy_bool*)data);
     }
     else if (PyDataType_FLAGCHK(descr, NPY_USE_GETITEM)) {
-        return PyArray_Descr_GETITEM(descr, base, data);
+        return PyArray_Descr_GETITEM(descr, (PyArrayObject *)base, data);
     }
     itemsize = descr->elsize;
     copyswap = descr->f->copyswap;

--- a/numpy/core/src/multiarray/textreading/parser_config.h
+++ b/numpy/core/src/multiarray/textreading/parser_config.h
@@ -53,8 +53,8 @@ typedef struct {
       * while normal object to string casts only accept ASCII, so it ensures
       * that that the object array already contains bytes and not strings.
       */
-     bool python_byte_converters;
-     bool c_byte_converters;
+     npy_bool python_byte_converters;
+     npy_bool c_byte_converters;
 } parser_config;
 
 

--- a/numpy/core/src/multiarray/textreading/readtext.c
+++ b/numpy/core/src/multiarray/textreading/readtext.c
@@ -222,10 +222,10 @@ _load_from_filelike_impl(HPyContext *ctx, HPy NPY_UNUSED(mod),
         .imaginary_unit = 'j',
         .delimiter_is_whitespace = false,
         .ignore_leading_whitespace = false,
-        .python_byte_converters = false,
-        .c_byte_converters = false,
+        .python_byte_converters = (npy_bool)false,
+        .c_byte_converters = (npy_bool)false,
     };
-    bool filelike = true;
+    npy_bool filelike = true;
 
     HPy arr = HPy_NULL;
 

--- a/numpy/core/src/multiarray/usertypes.c
+++ b/numpy/core/src/multiarray/usertypes.c
@@ -83,15 +83,16 @@ _default_nonzero(void *ip, void *arr)
 }
 
 static void
-_default_copyswapn(void *dst, npy_intp dstride, void *src,
-                   npy_intp sstride, npy_intp n, int swap, void *arr)
+_default_copyswapn(HPyContext * ctx, void *dst, npy_intp dstride, void *src,
+                   npy_intp sstride, npy_intp n, int swap, HPy hpy_arr)
 {
     npy_intp i;
     HPyArray_CopySwapFunc *copyswap;
     char *dstptr = dst;
     char *srcptr = src;
 
-    copyswap = PyArray_DESCR(arr)->f->copyswap;
+    PyObject * arr = HPy_AsPyObject(ctx, hpy_arr);
+    copyswap = PyArray_DESCR((PyArrayObject *)arr)->f->copyswap;
 
     for (i = 0; i < n; i++) {
         cpy_copyswap(copyswap, dstptr, srcptr, swap, arr);

--- a/numpy/core/src/umath/_scaled_float_dtype.c
+++ b/numpy/core/src/umath/_scaled_float_dtype.c
@@ -282,7 +282,7 @@ static PyObject *
 sfloat_str(PyArray_SFloatDescr *self)
 {
     HPyContext *ctx = npy_get_context(); 
-    HPy h_self = HPy_FromPyObject(ctx, self);
+    HPy h_self = HPy_FromPyObject(ctx, (PyObject *)self);
     HPy h_ret = sfloat_repr_impl(ctx, h_self);
     PyObject *ret = HPy_AsPyObject(ctx, h_ret);
     HPy_Close(ctx, h_self);

--- a/numpy/core/src/umath/ufunc_type_resolution.c
+++ b/numpy/core/src/umath/ufunc_type_resolution.c
@@ -860,7 +860,7 @@ PyUFunc_SimpleUniformOperationTypeResolver(
                     Py_INCREF(out_dtypes[iop]);
                 }
                 HPyContext *ctx = npy_get_context();
-                HPy *h_out_types = HPy_FromPyObjectArray(ctx, out_dtypes, ufunc->nargs);
+                HPy *h_out_types = HPy_FromPyObjectArray(ctx, (PyObject **)out_dtypes, ufunc->nargs);
                 HPy h_ufunc = HPy_FromPyObject(ctx, (PyObject *) ufunc);
                 hpy_raise_no_loop_found_error(ctx, h_ufunc, h_out_types);
                 HPy_CloseAndFreeArray(ctx, h_out_types, ufunc->nargs);
@@ -2318,7 +2318,7 @@ hpy_linear_search_userloop_type_resolver(HPyContext *ctx,
                 return -1;
             }
             CAPI_WARN("PyUFunc_Loop1d->arg_dtypes is a (PyArray_Descr **)!");
-            HPy *arg_dtypes = HPy_FromPyObjectArray(ctx, funcdata->arg_dtypes, funcdata->nargs);
+            HPy *arg_dtypes = HPy_FromPyObjectArray(ctx, (PyObject **)(funcdata->arg_dtypes), funcdata->nargs);
             for (; funcdata != NULL; funcdata = funcdata->next) {
                 int *types = funcdata->arg_types;
                 switch (hpy_ufunc_loop_matches(ctx, self, self_struct, op,
@@ -3108,7 +3108,9 @@ hpy_type_tuple_type_resolver(HPyContext *ctx,
 
     ufunc_name = ufunc_get_name_cstr(self_struct);
 
-    use_min_scalar = should_use_min_scalar(nin, op, 0, NULL);
+    hpy_abort_not_implemented("convert op to PyArrayObject**");
+    PyArrayObject ** dummy;
+    use_min_scalar = should_use_min_scalar(nin, dummy, 0, NULL);
 
     /* Fill in specified_types from the tuple or string */
     const char *bad_type_tup_msg = (

--- a/numpy/core/src/umath/wrapping_array_method.c
+++ b/numpy/core/src/umath/wrapping_array_method.c
@@ -245,7 +245,7 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
             continue;
         }
         wrapped_meth = (PyArrayMethodObject *)PyTuple_GetItem(item, 1);
-        if (!PyObject_TypeCheck((PyObject *)wrapped_meth, &PyArrayMethod_Type)) {
+        if (!PyObject_TypeCheck((PyObject *)wrapped_meth, PyArrayMethod_Type)) {
             PyErr_SetString(PyExc_TypeError,
                     "Matching loop was not an ArrayMethod.");
             goto finish;


### PR DESCRIPTION
These were almost all the fixes I needed to get a warning-less compilation on PyPy. I used this command line to build a wheel:
```
CFLAGS="-O0 -g3" python setup.py build --warn-error build_src --verbose-cfg bdist_wheel
```

PyPy still cannot cleanly load numpy, I get this after running the command above, which suggests something is off with the metaclass handling somewhere:
```
$ pip install dist/numpy-1.23.0.dev0+1466.g23f4a1898d-pp39-pypy39_pp73-linux_x86_64.whl
$ cd dist
$ python -c "import numpy"
$ python -c "import numpy"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/venv3pypy/lib/pypy3.9/site-packages/numpy/__init__.py", line 143, in <module>
    from . import lib
  File "/tmp/venv3pypy/lib/pypy3.9/site-packages/numpy/lib/__init__.py", line 21, in <module>
    from . import scimath as emath
  File "/tmp/venv3pypy/lib/pypy3.9/site-packages/numpy/lib/scimath.py", line 46, in <module>
    _ln2 = nx.log(2.0)
TypeError: object.__new__(float64) is not safe, use float64.__new__()

```